### PR TITLE
Bugfix/#16981 fixing wakeup call

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -431,7 +431,7 @@ rbcgroup_config "Configure cgroups" do
 end
 
 execute "force_chef_client_wakeup" do
-    command "/usr/lib/redborder/bin/rb_wakeup_chef"
+    command '/usr/lib/redborder/bin/rb_wakeup_chef.sh'
     ignore_failure true
     action ((sensor_id>0) ? :nothing : :run)
 end

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -14,23 +14,22 @@
 <%####################################################################### %>
 Defaults:redBorder !requiretty
 Defaults:rb-monitor !requiretty, !syslog 
-<%="
-redborder
-  ALL=NOPASSWD:SETENV: 
-    /usr/bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, 
-    /usr/lib/redborder/bin/rb_bypass.sh, 
-    /usr/lib/redborder/bin/rb_wakeup_chef.sh, 
-    /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, 
-    /usr/lib/redborder/bin/rb_update_geoip, 
-    /sbin/service chef-client restart, 
-    /usr/lib/redborder/bin/rb_u2pcap.sh, 
-    /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
-".gsub(/\s+/, ' ').strip %>
-<%="
-rb-monitor
-  ALL= NOPASSWD:
-    /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, 
-    /usr/lib/redborder/bin/rb_get_sensor.sh, 
-    /usr/lib/redborder/bin/rb_get_pfring_stats.sh, 
-    /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.#{["redborder"]["cdomain"]}
-".gsub(/\s+/, ' ').strip %>
+<% REDBORDER_PERMITTED_COMMANDS = [
+  '/usr/bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *', 
+  '/usr/bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *', 
+  '/usr/lib/redborder/bin/rb_bypass.sh', 
+  '/usr/lib/redborder/bin/rb_wakeup_chef.sh', 
+  '/usr/lib/redborder/bin/rb_disassociate_sensor.sh -f', 
+  '/usr/lib/redborder/bin/rb_update_geoip', 
+  '/sbin/service chef-client restart' , 
+  '/usr/lib/redborder/bin/rb_u2pcap.sh' , 
+  '/usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f'
+] %>
+redborder ALL=NOPASSWD:SETENV: <%= REDBORDER_PERMITTED_COMMANDS.join(', ') %>
+<% RBMONITOR_PERMITTED_COMMANDS = [
+  '/usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh', 
+  '/usr/lib/redborder/bin/rb_get_sensor.sh', 
+  '/usr/lib/redborder/bin/rb_get_pfring_stats.sh', 
+  '/bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.#{["redborder"]["cdomain"]}'
+] %>
+rb-monitor ALL= NOPASSWD: <%= RBMONITOR_PERMITTED_COMMANDS.join(', ') %>

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -14,5 +14,5 @@
 <%####################################################################### %>
 Defaults:redBorder !requiretty
 Defaults:rb-monitor !requiretty, !syslog 
-redBorder      ALL= NOPASSWD:SETENV: /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef, /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, /usr/lib/redborder/bin/rb_update_geoip, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
+redBorder      ALL= NOPASSWD:SETENV: /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef.sh, /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, /usr/lib/redborder/bin/rb_update_geoip, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
 rb-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -26,4 +26,11 @@ redborder
     /usr/lib/redborder/bin/rb_u2pcap.sh, 
     /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
 ".gsub(/\s+/, ' ').strip %>
-rb-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>
+<%="
+rb-monitor
+  ALL= NOPASSWD:
+    /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, 
+    /usr/lib/redborder/bin/rb_get_sensor.sh, 
+    /usr/lib/redborder/bin/rb_get_pfring_stats.sh, 
+    /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.#{["redborder"]["cdomain"]}
+".gsub(/\s+/, ' ').strip %>

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -14,5 +14,5 @@
 <%####################################################################### %>
 Defaults:redBorder !requiretty
 Defaults:rb-monitor !requiretty, !syslog 
-redBorder      ALL= NOPASSWD:SETENV: /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef.sh, /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, /usr/lib/redborder/bin/rb_update_geoip, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
+redborder      ALL= NOPASSWD:SETENV: /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef.sh, /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, /usr/lib/redborder/bin/rb_update_geoip, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
 rb-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -14,5 +14,16 @@
 <%####################################################################### %>
 Defaults:redBorder !requiretty
 Defaults:rb-monitor !requiretty, !syslog 
-redborder      ALL= NOPASSWD:SETENV: /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef.sh, /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, /usr/lib/redborder/bin/rb_update_geoip, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
+<%="
+redborder
+  ALL=NOPASSWD:SETENV: 
+    /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, 
+    /usr/lib/redborder/bin/rb_bypass.sh, 
+    /usr/lib/redborder/bin/rb_wakeup_chef.sh, 
+    /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, 
+    /usr/lib/redborder/bin/rb_update_geoip, 
+    /sbin/service chef-client restart, 
+    /usr/lib/redborder/bin/rb_u2pcap.sh, 
+    /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
+".gsub(/\s+/, ' ').strip %>
 rb-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>

--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -17,7 +17,7 @@ Defaults:rb-monitor !requiretty, !syslog
 <%="
 redborder
   ALL=NOPASSWD:SETENV: 
-    /bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, 
+    /usr/bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, 
     /usr/lib/redborder/bin/rb_bypass.sh, 
     /usr/lib/redborder/bin/rb_wakeup_chef.sh, 
     /usr/lib/redborder/bin/rb_disassociate_sensor.sh -f, 


### PR DESCRIPTION
rb_wakeup_chef doesn't exist and the norm is to call bash scripts as rb_wakeup_chef.sh

This wasn't part of the task but could fail if a redBorder user in the ips tries to execute rb_wakeup_chef with permissions needed.

Also the name is redborder, not redBorder