### PR TITLE
excluding chef-client

### DIFF
--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -64,5 +64,4 @@ node.default["redborder"]["namespaces"] = get_namespaces
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total)
-
+memory_services(sysmem_total, ['chef-client'])


### PR DESCRIPTION
Mirror of cookbook rb manager because chef-client is also part of this kind of machine