### PR TITLE
Add configure common cookbook call

### DIFF
--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -6,6 +6,7 @@ description      'Installs/Configures redborder ips'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.11'
 
+depends 'rb-common'
 depends 'geoip'
 depends 'snmp'
 depends 'rbmonitor'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -43,6 +43,10 @@ sensor_id = node["redborder"]["sensor_id"].to_i rescue 0
 
 # managers      = managers.sort{|a,b| (a["rb_time"]||999999999999999999999) <=> (b["rb_time"]||999999999999999999999)}
 
+rb_common_config "Configure common" do
+  action :configure
+end
+
 rb_selinux_config "Configure Selinux" do
   if shell_out("getenforce").stdout.chomp == "Disabled"
     action :remove


### PR DESCRIPTION
- Add a new 'common' cookbook for common settings

Related PRs: 
- https://github.com/redBorder/redborder-cookbooks/pull/32
- https://github.com/redBorder/cookbook-rb-common/pull/1
- https://github.com/redBorder/cookbook-rb-proxy/pull/23
- https://github.com/redBorder/cookbook-rb-manager/pull/140
- https://github.com/redBorder/redborder-manager/pull/124