### PR TITLE
Add full kernel release info in motd

### DIFF
--- a/resources/templates/default/motd.erb
+++ b/resources/templates/default/motd.erb
@@ -1,6 +1,6 @@
 
   Welcome to redborder-ng IPS [<%= node["hostname"] %>] (<%= node['platform'] %> - <%= node['platform_version'] %>):
-  Kernel: <%= node['os_version'].gsub("el9", "") %>
+  Kernel: <%= node['os_version'] %>
   
 <% if !node["redborder"].nil? and !node["redborder"]["rpms"].nil? %>
 <% node["redborder"]["rpms"].each do |k, v| %>


### PR DESCRIPTION
Changes: 
- Add full kernel release info in motd

Related PRs:
- https://github.com/redBorder/cookbook-rb-proxy/pull/26
- https://github.com/redBorder/cookbook-rb-manager/pull/142

More details: 

In motd:
```
Kernel: 5.14.0-427.13.1._4.x86_64
```

should be 5.14.0-427.13.1 or the full release info 5.14.0-427.13.1.el9_4.x86_64 (I chose this option in this PR), but the actual way 5.14.0-427.13.1._4.x86_64 is wrong.