### PR TITLE
Improvement/#18961 service list without chef

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -46,31 +46,26 @@ default['redborder']['ipsrules'] = {}
 
 # memory
 default['redborder']['memory_services'] = {}
-default['redborder']['memory_services']['chef-client'] = { 'count': 10, 'memory': 0 }
-default['redborder']['memory_services']['snmp'] = { 'count': 5, 'memory': 0, 'max_limit': 10000 }
-default['redborder']['memory_services']['redborder-monitor'] = { 'count': 5, 'memory': 0, 'max_limit': 20000 }
-default['redborder']['memory_services']['snortd'] = { 'count': 10, 'memory': 0 }
 default['redborder']['memory_services']['barnyard2'] = { 'count': 10, 'memory': 0 }
-
-# exclude mem services, setting memory to 0 for each.
-default['redborder']['excluded_memory_services'] = ['chef-client']
+default['redborder']['memory_services']['redborder-monitor'] = { 'count': 5, 'memory': 0, 'max_limit': 20000 }
+default['redborder']['memory_services']['snmp'] = { 'count': 5, 'memory': 0, 'max_limit': 10000 }
+default['redborder']['memory_services']['snortd'] = { 'count': 10, 'memory': 0 }
 
 default['redborder']['services'] = {}
-default['redborder']['services']['chef-client'] = true
-default['redborder']['services']['redborder-monitor'] = true
-default['redborder']['services']['snmp'] = true
-default['redborder']['services']['rsyslog'] = true
-default['redborder']['services']['snortd'] = true
 default['redborder']['services']['barnyard2'] = true
-default['redborder']['services']['clamav'] = true
+default['redborder']['services']['chef-client'] = true
 default['redborder']['services']['chrony'] = true
 default['redborder']['services']['redborder-exporter'] = true
+default['redborder']['services']['redborder-monitor'] = true
+default['redborder']['services']['rsyslog'] = true
+default['redborder']['services']['snmp'] = true
+default['redborder']['services']['snortd'] = true
 
-default['redborder']['systemdservices']['chef-client'] = ['chef-client']
-default['redborder']['systemdservices']['redborder-monitor'] = ['redborder-monitor']
-default['redborder']['systemdservices']['snmp'] = ['snmpd']
-default['redborder']['systemdservices']['rsyslog'] = ['rsyslog']
-default['redborder']['systemdservices']['snortd'] = ['snortd']
 default['redborder']['systemdservices']['barnyard2'] = ['barnyard2']
-default['redborder']['systemdservices']['redborder-exporter'] = ['rb-exporter']
+default['redborder']['systemdservices']['chef-client'] = ['chef-client']
 default['redborder']['systemdservices']['chrony'] = ['chronyd']
+default['redborder']['systemdservices']['redborder-exporter'] = ['rb-exporter']
+default['redborder']['systemdservices']['redborder-monitor'] = ['redborder-monitor']
+default['redborder']['systemdservices']['rsyslog'] = ['rsyslog']
+default['redborder']['systemdservices']['snmp'] = ['snmpd']
+default['redborder']['systemdservices']['snortd'] = ['snortd']

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -9,8 +9,7 @@ module RbIps
 
       node['redborder']['memory_services'].each do |name, mem_s|
         if node['redborder']['services'][name] &&
-           !excluded_services.include?(name) &&
-           !node['redborder']['excluded_memory_services'].include?(name)
+           !excluded_services.include?(name)
           memory_services_size += mem_s['count']
         end
 
@@ -23,8 +22,6 @@ module RbIps
 
       node['redborder']['memory_services'].each do |name, mem_s|
         next unless node['redborder']['services'][name] && !excluded_services.include?(name)
-
-        next unless !node['redborder']['excluded_memory_services'].include?(name)
 
         # service count memory assigned * system memory / assigned services memory size
         memory_serv[name] = (mem_s['count'] * sysmem_total / memory_services_size).round

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -463,7 +463,7 @@ rbcgroup_config 'Configure cgroups' do
 end
 
 rb_clamav_config 'Configure ClamAV' do
-  action(ips_services['clamav'] ? :add : :remove)
+  action :add
 end
 
 rb_chrony_config 'Configure Chrony' do

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -63,3 +63,17 @@ sysmem_total = (node['memory']['total'].to_i * 0.90).to_i
 
 # node attributes related with memory are changed inside the function to have simplicity using recursivity
 memory_services(sysmem_total)
+
+# Build service list for rbcli
+services = node['redborder']['services'] ||  []
+systemd_services = node['redborder']['systemdservices'] || []
+service_enablement = {}
+
+systemd_services.each do |service_name, systemd_name|
+  service_enablement[systemd_name.first] = services[service_name]
+end
+
+Chef::Log.info("Saving services enablement into /etc/redborder/services.json")
+File.open("/etc/redborder/services.json", "w") do |file|
+  file.write(JSON.pretty_generate(service_enablement))
+end

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -65,7 +65,7 @@ sysmem_total = (node['memory']['total'].to_i * 0.90).to_i
 memory_services(sysmem_total)
 
 # Build service list for rbcli
-services = node['redborder']['services'] ||  []
+services = node['redborder']['services'] || []
 systemd_services = node['redborder']['systemdservices'] || []
 service_enablement = {}
 
@@ -73,7 +73,5 @@ systemd_services.each do |service_name, systemd_name|
   service_enablement[systemd_name.first] = services[service_name]
 end
 
-Chef::Log.info("Saving services enablement into /etc/redborder/services.json")
-File.open("/etc/redborder/services.json", "w") do |file|
-  file.write(JSON.pretty_generate(service_enablement))
-end
+Chef::Log.info('Saving services enablement into /etc/redborder/services.json')
+File.write('/etc/redborder/services.json', JSON.pretty_generate(service_enablement))


### PR DESCRIPTION
Improvements:
- Alphabetically order list of memory_service, services and systemd_services
- Clamav is not a service and it is always added so I remove it from the service list
- Remove excluded_memory_services as chef-client was the only one excluded. We dont need to reserver mem for chef-client if is out of the cgroup anyway (with the 10% of the system should be OK)
- Store a list with enable/disable services in /etc/redborder/services.json so "rbcli service list" can list the service list without opscode-erchef running (usefull when this service goes down).