### PR TITLE
stop sending mails for failed sudo commands

### DIFF
--- a/resources/templates/default/redBorder.erb
+++ b/resources/templates/default/redBorder.erb
@@ -12,7 +12,8 @@
 <%# You should have received a copy of the GNU Affero General Public License License %>
 <%# along with redBorder. If not, see <http://www.gnu.org/licenses/>. %>
 <%####################################################################### %>
+Defaults    !mail_no_user
 Defaults:redborder !requiretty
 Defaults:redborder-monitor !requiretty, !syslog 
 redborder      ALL= NOPASSWD:SETENV: /usr/bin/env BOOTUP=none /usr/lib/redborder/bin/rb_get_sensor_rules.sh *, /usr/lib/redborder/bin/rb_bypass.sh, /usr/lib/redborder/bin/rb_wakeup_chef.sh, /usr/lib/redborder/bin/rb_disassociate.sh -f, /sbin/service chef-client restart, /usr/lib/redborder/bin/rb_u2pcap.sh *, /usr/lib/redborder/bin/rb_update_geoip, /usr/lib/redborder/bin/rb_update_redborder_rpms.sh -f
-redborder-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /usr/bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>
+redborder-monitor     ALL= NOPASSWD: /usr/lib/redborder/bin/rb_get_perfmonitor_stats.sh, /usr/lib/redborder/bin/rb_get_sensor.sh *, /usr/lib/redborder/bin/rb_get_pfring_stats.sh, /usr/bin/nice -n 19 /usr/sbin/fping -p 1 -c 10 kafka.<%= node["redborder"]["cdomain"] %>


### PR DESCRIPTION
stop sending mails for failed sudo commands and add wildcard for arguments in rb_get_sensor.sh commands

Redmine ticket: https://redmine.redborder.lan/issues/19105