### PR TITLE
Release 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-ips CHANGELOG
 ===============
 
+## 2.3.1
+
+  - jnavarrorb
+    - [e534d5a] Fix empty string
+
 ## 2.3.0
 
   - nilsver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-ips CHANGELOG
 ===============
 
+## 2.3.2
+
+  - nilsver
+    - [499881d] add check every 24h to clean metadata
+
 ## 2.3.1
 
   - jnavarrorb

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder ips'
-version          '2.3.0'
+version          '2.3.1'
 
 depends 'rb-common'
 depends 'geoip'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder ips'
-version          '2.3.1'
+version          '2.3.2'
 
 depends 'rb-common'
 depends 'geoip'

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -5,9 +5,10 @@
 
 extend RbIps::Helpers
 
-# Clean metadata to get packages upgrades
-execute 'Clean yum metadata' do
-  command 'yum clean metadata'
+# clean metadata to get packages upgrades, every 24h
+execute 'Clean dnf metadata' do
+  command 'dnf clean metadata && touch /var/cache/dnf/last_makecache'
+  only_if '[ -f /var/cache/dnf/last_makecache ] && [ "$(find /var/cache/dnf/last_makecache -mmin +1440)" ]'
 end
 
 # Stop rb-register


### PR DESCRIPTION
prepary_system taking too long as we yum cache clean metadata all the time by @nilsver in #71 